### PR TITLE
Improve test script

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,18 @@
 {
-    "presets": [
-        "es2015", "stage-0"
-    ],
-    "plugins": [
-        "transform-object-rest-spread",
-        "transform-es2015-destructuring",
+	"presets": [
+		"es2015", "stage-0"
+	],
+	"plugins": [
+		"transform-object-rest-spread",
+		"transform-es2015-destructuring",
 		"transform-runtime"
-    ],
-    "sourceMaps": "inline"
+	],
+	"sourceMaps": "inline",
+	"env": {
+		"test": {
+			"plugins": [
+				"istanbul"
+			]
+		}
+	}
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ install:
   - npm i
 script:
   - npm run lint
-  - npm run cover
+  - npm run test
 after_success:
   - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -9,26 +9,38 @@
 		"recompile": "npm run clean && npm run compile",
 		"clean": "rm -rf .compiled && mkdir -p .compiled/src && mkdir -p .compiled/tests",
 		"compile": "babel src --out-dir .compiled/src && babel tests --out-dir .compiled/tests",
-		"cover": "npm run recompile && cd .compiled/src && istanbul cover ../../node_modules/mocha/bin/_mocha *.js -R ../tests --coverage",
-		"coveralls": "cat .compiled/src/coverage/lcov.info | coveralls",
-		"test": "npm run recompile && mocha --require source-map-support/register ./.compiled/tests"
+		"coveralls": "cat coverage/lcov.info | coveralls",
+		"test": "cross-env NODE_ENV=test nyc --reporter=lcov mocha tests"
 	},
 	"author": "Steve Konves",
 	"license": "MIT",
 	"devDependencies": {
 		"babel-cli": "^6.18.0",
 		"babel-eslint": "^7.1.0",
+		"babel-plugin-istanbul": "^4.1.3",
 		"babel-plugin-transform-es2015-destructuring": "^6.18.0",
 		"babel-plugin-transform-object-rest-spread": "^6.16.0",
 		"babel-plugin-transform-runtime": "^6.22.0",
 		"babel-preset-es2015": "^6.18.0",
 		"babel-preset-stage-0": "^6.16.0",
+		"babel-register": "^6.24.1",
 		"chai": "^3.5.0",
+		"cross-env": "^4.0.0",
 		"coveralls": "^2.13.0",
 		"eslint": "^3.9.1",
 		"eslint-plugin-babel": "^3.3.0",
 		"istanbul": "^0.4.5",
 		"mocha": "^3.2.0",
+		"nyc": "^10.3.0",
 		"source-map-support": "^0.4.11"
+	},
+	"nyc": {
+		"require": [
+			"babel-register"
+		],
+		"include": "src",
+		"exclude": "tests",
+		"sourceMap": false,
+		"instrument": false
 	}
 }


### PR DESCRIPTION
This change measures coverage against the pre-transpiled code so that code coverage results are more useful.  Details are described at https://github.com/istanbuljs/babel-plugin-istanbul#usage.

Check coverage output at: https://coveralls.io/github/DriveTimeInc/stability-js?branch=coveralls